### PR TITLE
ENH: add debug preproc directive, install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set( CMAKE_AUTOUIC ON )
 # Look in the build directory for cmake modules
 SET( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/" )
 
+option(WITH_DEBUG "Use qDebug in source for debugging" OFF)
+
 find_package( Qt5 COMPONENTS Widgets REQUIRED )
 find_package( CURL REQUIRED )
 
@@ -27,4 +29,10 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/webphone.jar
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/settings.ini
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
+if(WITH_DEBUG)
+  target_compile_definitions(webphoneID PRIVATE -DWITH_QDEBUG)
+endif()
+
 target_link_libraries( webphoneID PRIVATE Qt5::Widgets curl )
+
+install(TARGETS webphoneID RUNTIME DESTINATION bin)

--- a/IDEntryDialog.cpp
+++ b/IDEntryDialog.cpp
@@ -11,10 +11,7 @@
 #include <QPushButton>
 #include <QSettings>
 
-// UNCOMMENT TO SHOW DEBUG INFO VIA qDebug() << "someinfo";
-#define DEBUG_CLI
-
-#ifdef DEBUG_CLI
+#ifdef WITH_QDEBUG
   #include <QDebug>
 #endif
 
@@ -81,7 +78,7 @@ IDEntryDialog::IDEntryDialog(QWidget *parent)
           QString auth = "Authorization: Basic ";
           auth.append(userPass.toUtf8().toBase64());
 
-#ifdef DEBUG_CLI
+#ifdef WITH_QDEBUG
           qDebug() << "authorization string: " << auth;
 #endif
 
@@ -123,7 +120,7 @@ IDEntryDialog::IDEntryDialog(QWidget *parent)
             QJsonDocument jsonDoc = QJsonDocument::fromJson(readBuffer,&jsonErr);
             QJsonObject jsonObj = jsonDoc.object();
 
-#ifdef DEBUG_CLI
+#ifdef WITH_QDEBUG
             qDebug() << "readbuffer: " << readBuffer;
             qDebug() << "as compact json: " << jsonDoc.toJson(QJsonDocument::Indented);
 #endif
@@ -155,7 +152,7 @@ IDEntryDialog::IDEntryDialog(QWidget *parent)
                     commandStream << QString("%1:%2").arg(key,m_settingsMap[key]);
               }
 
-#ifdef DEBUG_CLI
+#ifdef WITH_QDEBUG
               qDebug() << "system command: " << commandStream.join(" ");
 #endif
               system( commandStream.join(" ").toStdString().c_str() );


### PR DESCRIPTION
- add option WITH_DEBUG (default OFF) to enable use of qDebug()
  statements in code
- add install directive